### PR TITLE
Successfully tested on LED strip

### DIFF
--- a/pico/dma_ws2812.py
+++ b/pico/dma_ws2812.py
@@ -1,12 +1,14 @@
 # Example based on pio_ws2812.py, but modified to use
 # a DMA channel to push out the data to the PIO
 
+# https://cdn-shop.adafruit.com/datasheets/WS2812B.pdf
+# Example based on pio_ws2812.py, but modified to use
+# a DMA channel to push out the data to the PIO
+
 import array, time
 from machine import Pin
 import rp2
-
-# Configure the number of WS2812 LEDs.
-NUM_LEDS = 9
+import dma, uctypes
 
 PIO0_BASE = 0x50200000
 PIO0_BASE_TXF0 = PIO0_BASE+0x10
@@ -15,7 +17,7 @@ PIO0_BASE_TXF0 = PIO0_BASE+0x10
     sideset_init=rp2.PIO.OUT_LOW,
     out_shiftdir=rp2.PIO.SHIFT_LEFT,
     autopull=True,
-    pull_thresh=24,
+    pull_thresh=8,
 )
 def ws2812():
     # fmt: off
@@ -39,25 +41,37 @@ sm = rp2.StateMachine(0, ws2812, freq=8_000_000, sideset_base=Pin(2))
 # Start the StateMachine, it will wait for data on its FIFO.
 sm.active(1)
 
-# Dummy data
-ar = array.array("I", [0 for _ in range(NUM_LEDS)])
-ar[0] = 0xff3f0f00
-ar[1] = 0xaa00aa00
-
 # starts the transfer, using DMA channel 0
-def dma_out():
-    import dma, uctypes
+def dma_out(data, bytes_count):
     dma.init_channels()
     d0=dma.CHANNELS[0]
-    d0.CTRL_TRIG.EN = 0
-    d0.TRANS_COUNT = NUM_LEDS
-    d0.READ_ADDR = uctypes.addressof(ar)
+    d0.CTRL_TRIG_RAW = 0
+    d0.AL1_CTRL = 0
+
+    d0.TRANS_COUNT = bytes_count
+    d0.READ_ADDR = uctypes.addressof(data)
     d0.WRITE_ADDR = PIO0_BASE_TXF0
-    d0.CTRL_TRIG.INCR_WRITE = 0
+
     d0.CTRL_TRIG.INCR_READ = 1
-    d0.CTRL_TRIG.DATA_SIZE = 2
+    d0.CTRL_TRIG.INCR_WRITE = 0
+    d0.CTRL_TRIG.DATA_SIZE = 0  # 0x0 → SIZE_BYTE
+    d0.CTRL_TRIG.HIGH_PRIO = 1
+
     d0.CTRL_TRIG.EN = 1
 
+# Configure the number Leds. One WS2812 LEDs requires 3 bytes for GRB.
+NUM_BYTES = 240
 
+ar = bytearray(NUM_BYTES)
 
+# First LED is green
+ar[0] = 0xFF # Green
+ar[1] = 0x00 # Red
+ar[2] = 0x00 # Blue
+
+ar[12] = 0x00 # Green
+ar[13] = 0xFF # Red
+ar[14] = 0x00 # Blue
+
+dma_out(data=ar, bytes_count=NUM_BYTES)
 


### PR DESCRIPTION
The implementation just transmitted the first 40 bits.

This PR initializes the DMA correctly and works like a charm on long LED stripes.